### PR TITLE
[ZK-001] feat: ZKSync provider types

### DIFF
--- a/.changeset/mighty-terms-rest.md
+++ b/.changeset/mighty-terms-rest.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/sdk': minor
 ---
 
 ZKSync Provider types with builders

--- a/.changeset/mighty-terms-rest.md
+++ b/.changeset/mighty-terms-rest.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+ZKSync Provider types with builders

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -48,7 +48,8 @@
     "ts-node": "^10.8.0",
     "tsx": "^4.19.1",
     "typescript": "5.3.3",
-    "yaml": "2.4.5"
+    "yaml": "2.4.5",
+    "zksync-ethers": "^5.10.0"
   },
   "type": "module",
   "exports": {

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -21,6 +21,11 @@ import type {
   Transaction as VTransaction,
   TransactionReceipt as VTransactionReceipt,
 } from 'viem';
+import {
+  Contract as ZKSyncBaseContract,
+  Provider as ZKSyncBaseProvider,
+  types as zkSyncTypes,
+} from 'zksync-ethers';
 
 import { Annotated, ProtocolType } from '@hyperlane-xyz/utils';
 
@@ -31,6 +36,7 @@ export enum ProviderType {
   CosmJs = 'cosmjs',
   CosmJsWasm = 'cosmjs-wasm',
   GnosisTxBuilder = 'gnosis-txBuilder',
+  ZkSync = 'zksync',
 }
 
 export const PROTOCOL_TO_DEFAULT_PROVIDER_TYPE: Record<
@@ -124,13 +130,19 @@ export interface CosmJsWasmProvider
   provider: Promise<CosmWasmClient>;
 }
 
+export interface ZKSyncProvider extends TypedProviderBase<ZKSyncBaseProvider> {
+  type: ProviderType.ZkSync;
+  provider: ZKSyncBaseProvider;
+}
+
 export type TypedProvider =
   | EthersV5Provider
   // | EthersV6Provider
   | ViemProvider
   | SolanaWeb3Provider
   | CosmJsProvider
-  | CosmJsWasmProvider;
+  | CosmJsWasmProvider
+  | ZKSyncProvider;
 
 /**
  * Contracts with discriminated union of provider type
@@ -169,13 +181,19 @@ export interface CosmJsWasmContract
   contract: CosmWasmContract;
 }
 
+export interface ZKSyncContract extends TypedContractBase<ZKSyncBaseContract> {
+  type: ProviderType.ZkSync;
+  contract: ZKSyncBaseContract;
+}
+
 export type TypedContract =
   | EthersV5Contract
   // | EthersV6Contract
   | ViemContract
   | SolanaWeb3Contract
   | CosmJsContract
-  | CosmJsWasmContract;
+  | CosmJsWasmContract
+  | ZKSyncBaseContract;
 
 /**
  * Transactions with discriminated union of provider type
@@ -214,6 +232,12 @@ export interface CosmJsWasmTransaction
   extends TypedTransactionBase<ExecuteInstruction> {
   type: ProviderType.CosmJsWasm;
   transaction: ExecuteInstruction;
+}
+
+export interface ZKSyncTransaction
+  extends TypedTransactionBase<zkSyncTypes.TransactionRequest> {
+  type: ProviderType.ZkSync;
+  transaction: zkSyncTypes.TransactionRequest;
 }
 
 export type TypedTransaction =
@@ -263,9 +287,16 @@ export interface CosmJsWasmTransactionReceipt
   receipt: DeliverTxResponse;
 }
 
+export interface ZKSyncTransactionReceipt
+  extends TypedTransactionReceiptBase<zkSyncTypes.TransactionReceipt> {
+  type: ProviderType.ZkSync;
+  receipt: zkSyncTypes.TransactionReceipt;
+}
+
 export type TypedTransactionReceipt =
   | EthersV5TransactionReceipt
   | ViemTransactionReceipt
   | SolanaWeb3TransactionReceipt
   | CosmJsTransactionReceipt
-  | CosmJsWasmTransactionReceipt;
+  | CosmJsWasmTransactionReceipt
+  | ZKSyncTransactionReceipt;

--- a/typescript/sdk/src/providers/providerBuilders.ts
+++ b/typescript/sdk/src/providers/providerBuilders.ts
@@ -3,8 +3,9 @@ import { StargateClient } from '@cosmjs/stargate';
 import { Connection } from '@solana/web3.js';
 import { providers } from 'ethers';
 import { createPublicClient, http } from 'viem';
+import { Provider as ZKProvider } from 'zksync-ethers';
 
-import { ProtocolType, isNumeric } from '@hyperlane-xyz/utils';
+import { ProtocolType, assert, isNumeric } from '@hyperlane-xyz/utils';
 
 import { ChainMetadata, RpcUrl } from '../metadata/chainMetadataTypes.js';
 
@@ -16,6 +17,7 @@ import {
   SolanaWeb3Provider,
   TypedProvider,
   ViemProvider,
+  ZKSyncProvider,
 } from './ProviderType.js';
 import { HyperlaneSmartProvider } from './SmartProvider/SmartProvider.js';
 import { ProviderRetryOptions } from './SmartProvider/types.js';
@@ -109,12 +111,29 @@ export function defaultCosmJsWasmProviderBuilder(
   };
 }
 
+export function defaultZKSyncProviderBuilder(
+  rpcUrls: RpcUrl[],
+  network: providers.Networkish,
+): ZKSyncProvider {
+  assert(rpcUrls.length, 'No RPC URLs provided');
+  const url = rpcUrls[0].http;
+  const provider = new ZKProvider(url, network);
+  return { type: ProviderType.ZkSync, provider };
+}
+
 // Kept for backwards compatibility
 export function defaultProviderBuilder(
   rpcUrls: RpcUrl[],
   _network: number | string,
 ): providers.Provider {
   return defaultEthersV5ProviderBuilder(rpcUrls, _network).provider;
+}
+
+export function defaultZKProviderBuilder(
+  rpcUrls: RpcUrl[],
+  _network: number | string,
+): ZKProvider {
+  return defaultZKSyncProviderBuilder(rpcUrls, _network).provider;
 }
 
 export type ProviderBuilderMap = Record<
@@ -128,6 +147,7 @@ export const defaultProviderBuilderMap: ProviderBuilderMap = {
   [ProviderType.SolanaWeb3]: defaultSolProviderBuilder,
   [ProviderType.CosmJs]: defaultCosmJsProviderBuilder,
   [ProviderType.CosmJsWasm]: defaultCosmJsWasmProviderBuilder,
+  [ProviderType.ZkSync]: defaultZKSyncProviderBuilder,
 };
 
 export const protocolToDefaultProviderBuilder: Record<


### PR DESCRIPTION
### Description

ZKSync PR 1

This PR introduces ZKSync support for Solidity contracts and restructures build files directory structure.

### Drive-by changes

- Added ZKSync compilation support using zksolc via `@matterlabs/hardhat-zksync-solc`
- Restructured typechain directory location to `core-utils/typechain`
- Decoupled Hardhat configuration for ZKSync from EVM.
- Updated build process to handle both standard and ZKSync contract artifacts

### Related issues

None

### Backward compatibility

Yes

### Testing

Testing was previously in [feat: zksync support](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4725) PR
